### PR TITLE
Adding pandas to the requirements

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -6,3 +6,4 @@ myst_nb==0.12.3
 nimare[duecredit]==0.0.12rc1
 pytest==6.2.5
 repo2data==2.4.4
+pandas==1.4.3


### PR DESCRIPTION
Old versions of pandas cannot read the data from the pickle files.

The error messages look like:
```
AttributeError: Can't get attribute 'new_block' on <module 'pandas.core.internals.blocks' from '/usr/local/lib/python3.9/site-packages/pandas/core/internals/blocks.py'>
```